### PR TITLE
Исправил адреса для инсты

### DIFF
--- a/Разблокировка множества сервисов(пример - ChatGPT)/Адреса для zapret под Instagram.txt
+++ b/Разблокировка множества сервисов(пример - ChatGPT)/Адреса для zapret под Instagram.txt
@@ -1,4 +1,5 @@
 # Скопировать в list-general.txt
+# Если Инстаграм все еще не работает, то нужно в настройках DNS указать 1.1.1.1 и в cmd выполнить команду ipconfig /flushdns
 
 instagram.com
 cdninstagram.com


### PR DESCRIPTION
Запрет сам подтягивает все сабдомены основного домена, поэтому смысла дублировать instagram.com два раза нет